### PR TITLE
change rumpkernel.org links to github.com/rumpkernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Wiki Guidelines
 ===============
 
-This page lists high-level guidelines for editing http://wiki.rumpkernel.org/.
+This page lists high-level guidelines for editing https://github.com/rumpkernel/wiki/wiki/.
 
 
 Titles
@@ -12,13 +12,13 @@ used for creating the navbar on the wiki.
 
 The current categories are:
 
-* _[Builds](http://wiki.rumpkernel.org/Builds)_: automated builds, tests, etc.
-* _[Howto](http://wiki.rumpkernel.org/Howto)_: Howtos document specific tasks
-* _[Info](http://wiki.rumpkernel.org/Info)_: General information, e.g. historical info, TODO-lists, etc.
-* _[Performance](http://wiki.rumpkernel.org/Performance)_: important points about optimization, tuning, etc.
-* _[People](http://wiki.rumpkernel.org/People)_: personal spaces for rump kernel project contributors.  Edit only your own page.
-* _[Project ideas](http://wiki.rumpkernel.org/Project-Ideas)_: detailed description of a project looking for idle hands.
-* _[Tutorial](http://wiki.rumpkernel.org/Tutorial)_: Instructions starting from zero and working towards mastering a subject area (e.g. debugging or networking)
+* _[Builds](https://github.com/rumpkernel/wiki/wiki/Builds)_: automated builds, tests, etc.
+* _[Howto](https://github.com/rumpkernel/wiki/wiki/Howto)_: Howtos document specific tasks
+* _[Info](https://github.com/rumpkernel/wiki/wiki/Info)_: General information, e.g. historical info, TODO-lists, etc.
+* _[Performance](https://github.com/rumpkernel/wiki/wiki/Performance)_: important points about optimization, tuning, etc.
+* _[People](https://github.com/rumpkernel/wiki/wiki/People)_: personal spaces for rump kernel project contributors.  Edit only your own page.
+* _[Project ideas](https://github.com/rumpkernel/wiki/wiki/Project-Ideas)_: detailed description of a project looking for idle hands.
+* _[Tutorial](https://github.com/rumpkernel/wiki/wiki/Tutorial)_: Instructions starting from zero and working towards mastering a subject area (e.g. debugging or networking)
 
 If the article does not fit into the existing categories, please propose
 a new category on the rumpkernel-users@freelists.org mailing list.
@@ -26,8 +26,8 @@ a new category on the rumpkernel-users@freelists.org mailing list.
 Additionally, the following categories exist, but they should be used
 only if the respective code exists and is available:
 
-* _[Repo](http://wiki.rumpkernel.org/Repo)_: main pages for repositories hosted under http://repo.rumpkernel.org/
-* _[Platforms](http://wiki.rumpkernel.org/Platforms)_: descriptions of platforms that rump kernels run on
+* _[Repo](https://github.com/rumpkernel/wiki/wiki/Repo)_: main pages for repositories hosted under https://github.com/rumpkernel/
+* _[Platforms](https://github.com/rumpkernel/wiki/wiki/Platforms)_: descriptions of platforms that rump kernels run on
 
 Do not change titles after an article has been published, since that will
 alter the article's URL and render any hyperlinks to the article invalid.
@@ -42,10 +42,9 @@ e.g. to link to the platform page you could use
 The advantage of this format is that dead links will be flagged when
 the page is rendered.
 
-To link to this wiki from an external source, use the URL `http://wiki.rumpkernel.org/article-name`,
-e.g. http://wiki.rumpkernel.org/Platforms for the platforms page.
-To link to a rump kernel repository (currently hosted on Github), use `http://repo.rumpkernel.org/reponame`, e.g. http://repo.rumpkernel.org/buildrump.sh for buildrump.sh.  Avoid linking to
-non-rumpkernel.org URLs.
+To link to this wiki from an external source, use the URL `https://github.com/rumpkernel/wiki/wiki/article-name`,
+e.g. https://github.com/rumpkernel/wiki/wiki/Platforms for the platforms page.
+To link to a rump kernel repository (currently hosted on Github), use `https://github.com/rumpkernel/`, e.g. https://github.com/rumpkernel/buildrump.sh for buildrump.sh.
 
 
 License

--- a/logo/README.md
+++ b/logo/README.md
@@ -1,9 +1,9 @@
 Logo and usage guidelines
 =========================
 
-See [LICENSE](http://logo.rumpkernel.org/LICENSE).
+See [LICENSE](LICENSE).
 
-You are requested to link the logo to rumpkernel.org where feasible.
+You are requested to link the logo to https://github.com/rumpkernel/ where feasible.
 Use the svg format logo where possible.
 
 In case of questions, e.g. about using the logo in a given scenario,


### PR DESCRIPTION
Replace http://wiki.rumpkernel.org/
   with https://github.com/rumpkernel/wiki/wiki/

Replace http://repo.rumpkernel.org/
   with https://github.com/rumpkernel/